### PR TITLE
Fix products loading issue.

### DIFF
--- a/src/actions/productsActions.js
+++ b/src/actions/productsActions.js
@@ -12,7 +12,11 @@ export const getProducts = index => dispatch => {
   // Default the index to 0 if not given.
   index = index == null ? 0 : index;
 
-  dispatch(setProductLoading());
+  // getVendorBatch and getCategoryBatch set loading: true
+  // if either data is not loaded yet.
+  // if we set loading here, it will refresh the render too many times
+  // which results in losing the scroll wheel position...
+  //dispatch(setProductLoading());
   axios
     .get(PRODUCT_API_GATEWAY + `/get/${index}/default`)
     .then(res => {
@@ -20,6 +24,7 @@ export const getProducts = index => dispatch => {
         type: types.GET_PRODUCTS,
         payload: res.data
       });
+
       if (!isEmpty(res.data[0])) {
         if (!isEmpty(res.data[0].productId)) {
           let vendorIdArray = '';
@@ -95,7 +100,11 @@ export const setProductAdding = () => {
 };
 
 export const addProduct = newProd => dispatch => {
-  dispatch(setProductLoading());
+  // again, also here...
+  // getVendorBatch and getCategoryBatch handle the loading state variable
+  // if we call it too early, due to state changes between other methods...
+  // the page reloads and shows the "spinning wheel" which causes loss in scroll position
+  //dispatch(setProductLoading());
   axios
     .put(PRODUCT_API_GATEWAY + '/add', newProd)
     .then(res => {

--- a/src/components/portal/categories/Categories.js
+++ b/src/components/portal/categories/Categories.js
@@ -25,13 +25,16 @@ class Categories extends Component {
     });
   }
 
-  shouldComponentUpdate() {
-    if (this.props.category.updateOnce) {
+  componentDidUpdate() {
+    if (this.props.category.updateOnce)
       this.props.setCategoryUpdated();
-      return true;
-    }
+  }
 
-    return this.props.category.loading || false;
+  shouldComponentUpdate() {
+    if (this.props.category.updateOnce || this.props.category.loading)
+      return true;
+
+    return false;
   }
 
   loadMore() {

--- a/src/components/portal/products/Products.js
+++ b/src/components/portal/products/Products.js
@@ -13,7 +13,6 @@ import {
 import isEmpty from '../../../validation/is-empty';
 import CategoryTypeAhead from '../categories/CategoryTypeAhead';
 
-
 class Products extends Component {
   componentDidMount() {
     // Detect when scrolled to bottom.
@@ -29,11 +28,14 @@ class Products extends Component {
     });
   }
 
-  shouldComponentUpdate() {
-    if (this.props.product.updateOnce || this.props.product.loading) {
+  componentDidUpdate() {
+    if (this.props.product.updateOnce)
       this.props.setProductUpdated();
+  }
+
+  shouldComponentUpdate() {
+    if (this.props.product.updateOnce || this.props.product.loading)
       return true;
-    }
 
     return false;
   }

--- a/src/components/portal/vendor/Vendor.js
+++ b/src/components/portal/vendor/Vendor.js
@@ -21,13 +21,16 @@ class Vendor extends Component {
     });
   }
 
-  shouldComponentUpdate() {
-    if (this.props.vendor.updateOnce) {
+  componentDidUpdate() {
+    if (this.props.vendor.updateOnce)
       this.props.setVendorUpdated();
-      return true;
-    }
+  }
 
-    return this.props.vendor.loading || false;
+  shouldComponentUpdate() {
+    if (this.props.vendor.updateOnce || this.props.vendor.loading)
+      return true;
+
+    return false;
   }
 
   loadMore() {

--- a/src/reducers/productReducer.js
+++ b/src/reducers/productReducer.js
@@ -6,6 +6,8 @@ const initialState = {
   product_category: null,
   product_vendor: null,
   hasMore: false,
+  loadingVendors: false,
+  loadingCategories: false,
   index: 0
 };
 
@@ -47,7 +49,9 @@ export default function(state = initialState, action) {
         ...state,
         products: newProducts,
         hasMore: hasMore,
-        index: index
+        index: index,
+        loadingVendors: true,
+        loadingCategories: true
       };
     case types.GET_PRODUCT:
       return {
@@ -65,7 +69,9 @@ export default function(state = initialState, action) {
         ...state,
         products: newProducts2,
         hasMore: hasMore2,
-        updateOnce: true
+        //updateOnce: true,
+        loadingVendors: true,
+        loadingCategories: true
       };
     case types.PRODUCTS_DELETING:
       return {
@@ -91,11 +97,12 @@ export default function(state = initialState, action) {
       const newProductVendor = isEmpty(action.payload)
         ? currentProductVendor
         : currentProductVendor.concat(action.payload);
-      const loadingNew = state.product_category == null;
+      const loadingNew = state.loadingCategories;
       return {
         ...state,
         product_vendor: newProductVendor,
-        loading: loadingNew
+        loading: loadingNew,
+        loadingVendors: false
       };
     case types.GET_PRODUCT_CATEGORY:
       const currentProductCat = isEmpty(state.product_category)
@@ -104,11 +111,12 @@ export default function(state = initialState, action) {
       const newProductCat = isEmpty(action.payload)
         ? currentProductCat
         : currentProductCat.concat(action.payload);
-      const loadingNew2 = state.product_vendor == null;
+      const loadingNew2 = state.loadingVendors;
       return {
         ...state,
         product_category: newProductCat,
-        loading: loadingNew2
+        loading: loadingNew2,
+        loadingCategories: false
       };
     case types.PRODUCTS_LOADED:
       return {
@@ -122,6 +130,8 @@ export default function(state = initialState, action) {
         products: null,
         product_category: null,
         product_vendor: null,
+        loadingCategories: null,
+        loadingVendors: null,
         index: 0
       };
     default:


### PR DESCRIPTION
Because state.loading was set to true at the very beginning:
Once the state is updated in any way, e.g. not even to render something it would automatically try and push the code even with other functions loading in the background.

Solution:
Because products ALWAYS loads batched info from categories and vendors. I added state.loading into the reducer of those two functions, and added a .loadingVendor and .loadingCategory variables in the state which are referenced.

Also I have moved the setComponentUpdated() function into the componentDidUpdate instead of the componentShouldUpdate as it was in the correct location...

Also because I was checking if vendor and category info was null... second page would claim its already loaded because data was present. Thus the need to maintain two other booleans.

axios is asynchronous. sometimes it fires random order as well, thus the check for loading variable in both reducer cases.