### PR TITLE
Allow local devs to use local API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ npm install
 
 ```sh
 npm start
-``` 
+```
 
+```sh
+npm run local
+``` 
 
 Find the output at:
 ```sh

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "axios-cache-adapter": "^2.0.0",
     "bootstrap": "^4.1.1",
     "classnames": "^2.2.6",
+    "cross-env": "^5.2.0",
     "jquery": "^3.3.1",
     "jwt-decode": "^2.2.0",
     "localforage": "^1.7.2",
@@ -40,8 +41,5 @@
     "build": "cross-env REACT_APP_ENV=production react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  },
-  "devDependencies": {
-    "cross-env": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,13 @@
     "validator": "^10.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "cross-env REACT_APP_ENV=production react-scripts start",
+    "local": "cross-env REACT_APP_ENV=development react-scripts start",
+    "build": "cross-env REACT_APP_ENV=production react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "cross-env": "^5.2.0"
   }
 }

--- a/src/actions/microservices.js
+++ b/src/actions/microservices.js
@@ -1,8 +1,19 @@
-export const VENDOR_API_GATEWAY =
-  'https://api.alt.ausgrads.academy/vendor';
-export const CATEGORY_API_GATEWAY =
-  'https://api.alt.ausgrads.academy/category';
-export const PRODUCT_API_GATEWAY =
-  'https://api.alt.ausgrads.academy/product';
-export const USER_API_GATEWAY =
-  'https://api.alt.ausgrads.academy/user';
+const CATEGORY_API_PROD  = 'https://api.alt.ausgrads.academy/category';
+const PRODUCT_API_PROD   = 'https://api.alt.ausgrads.academy/product';
+const USER_API_PROD      = 'https://api.alt.ausgrads.academy/user';
+const VENDOR_API_PROD    = 'https://api.alt.ausgrads.academy/vendor';
+
+const CATEGORY_API_DEV  = 'http://localhost:10001';
+const PRODUCT_API_DEV   = 'http://localhost:10005';
+const USER_API_DEV      = 'http://localhost:10002';
+const VENDOR_API_DEV    = 'http://localhost:10000';
+
+// prod = true, test = true, dev = false
+let PRODUCTION = false;
+if (process.env.REACT_APP_ENV !== "development")
+  PRODUCTION = true;
+
+export const CATEGORY_API_GATEWAY = PRODUCTION ? CATEGORY_API_PROD  : CATEGORY_API_DEV;
+export const PRODUCT_API_GATEWAY  = PRODUCTION ? PRODUCT_API_PROD   : PRODUCT_API_DEV;
+export const USER_API_GATEWAY     = PRODUCTION ? USER_API_PROD      : USER_API_DEV;
+export const VENDOR_API_GATEWAY   = PRODUCTION ? VENDOR_API_PROD    : VENDOR_API_DEV;

--- a/src/actions/microservices.js
+++ b/src/actions/microservices.js
@@ -1,8 +1,10 @@
+const AUTH_API_PROD      = 'https://api.alt.ausgrads.academy';
 const CATEGORY_API_PROD  = 'https://api.alt.ausgrads.academy/category';
 const PRODUCT_API_PROD   = 'https://api.alt.ausgrads.academy/product';
 const USER_API_PROD      = 'https://api.alt.ausgrads.academy/user';
 const VENDOR_API_PROD    = 'https://api.alt.ausgrads.academy/vendor';
 
+const AUTH_API_DEV      = 'http://localhost:8765';
 const CATEGORY_API_DEV  = 'http://localhost:10001';
 const PRODUCT_API_DEV   = 'http://localhost:10005';
 const USER_API_DEV      = 'http://localhost:10002';
@@ -13,6 +15,7 @@ let PRODUCTION = false;
 if (process.env.REACT_APP_ENV !== "development")
   PRODUCTION = true;
 
+export const AUTH_API_GATEWAY     = PRODUCTION ? AUTH_API_PROD      : AUTH_API_DEV;
 export const CATEGORY_API_GATEWAY = PRODUCTION ? CATEGORY_API_PROD  : CATEGORY_API_DEV;
 export const PRODUCT_API_GATEWAY  = PRODUCTION ? PRODUCT_API_PROD   : PRODUCT_API_DEV;
 export const USER_API_GATEWAY     = PRODUCTION ? USER_API_PROD      : USER_API_DEV;


### PR DESCRIPTION
Added new command to start the react project and point to local API microservices.

Use "npm run local" to point to your own localhost.
"npm start" will continue pointing to the live server, so will "npm build".