### PR TITLE
Fixed category typeahead warning (v. small)

### DIFF
--- a/src/actions/productsActions.js
+++ b/src/actions/productsActions.js
@@ -427,14 +427,13 @@ export const editProductInventory = newInfo => dispatch => {
 export const filterProductsByCategory = inputs => dispatch => {
   dispatch(setProductLoading());
   dispatch(clearCurrentProducts());
-  
   axios
     .get(
       PRODUCT_API_GATEWAY +
         `/bycategory/${inputs.cur_id}/${inputs.index}/default`
     )
     .then(res => {
-      dispatch(refreshProductData(res.data, true));
+      dispatch(refreshProductData(res.data, inputs.filtered));
     })
     .catch(err => {
       dispatch(setProductUpdated());

--- a/src/components/portal/categories/CategoryTypeAhead.js
+++ b/src/components/portal/categories/CategoryTypeAhead.js
@@ -84,7 +84,7 @@ class CategoryTypeAhead extends Component {
                 type="button"
                 name={"No Results"}
                 value={0}
-                onClick={0}
+                onClick={() => {return;}}
               >
                 {'No results found'}
               </button>

--- a/src/components/portal/common/CategoryGridList.js
+++ b/src/components/portal/common/CategoryGridList.js
@@ -24,7 +24,8 @@ class CategoryGridList extends Component {
   componentWillMount() {
     this.props.filterProductsByCategory({
       cur_id: this.props.match.params.catId,
-      index: 0
+      index: 0,
+      filtered: true
     });
   }
 


### PR DESCRIPTION
Category typeahead was throwing a warning in console that didn't affect anything but was ugly. It was about the onClickHandler provided to the typeahead results if nothing was found.