### PR TITLE
Defect/griz-352 (Fixed crash on searching products)

### DIFF
--- a/src/components/portal/products/ProductList.js
+++ b/src/components/portal/products/ProductList.js
@@ -94,7 +94,7 @@ class ProductList extends Component {
   render() {
     //updated this to get the product from the global state instead of the parent
     const product = this.props.product.products[this.props.index];
-    if (!isEmpty(product))
+    if (!isEmpty(product)) {
       return (
         <tr>
           <th scope="row">{product.productId}</th>
@@ -143,6 +143,9 @@ class ProductList extends Component {
           </td>
         </tr>
       );
+    } else {
+      return (<tr />);
+    }
   }
 }
 

--- a/src/reducers/productReducer.js
+++ b/src/reducers/productReducer.js
@@ -6,6 +6,9 @@ const initialState = {
   // Stores ALL products. Shouldn't clear this.
   products: [],
 
+  // Stores ALL products images.
+  images: [],
+
   // Stores ALL product categories.
   product_category: [],
 
@@ -201,6 +204,38 @@ export default function(state = initialState, action) {
             ? action.payload.slice(0, 12)
             : action.payload
       };
+    case types.GET_PRODUCT_IMAGE:
+      let newImage = action.payload;
+      let productId = action.productId;
+
+      let currentImages = isEmpty(state.images) ? [] : state.images;
+      let oldImages = isEmpty(currentImages[productId]) ? [] : currentImages[productId];
+
+      // prevent duplicate images.
+      let newImages = isEmpty(newImage)
+        ? oldImages :
+        [
+          ...new Map(
+            oldImages
+              .concat(newImage)
+              .map(o => [o['imgName'], o])
+          ).values()
+        ];
+
+      currentImages[productId] = newImages;
+
+      return {
+        ...state,
+        images: currentImages
+      }
+    case types.CLEAR_PRODUCT_IMAGES:
+      productId = action.payload;
+      newImages = isEmpty(state.images) ? [] : state.images;
+      newImages[productId] = [];
+      return {
+        ...state,
+        images: newImages
+      }
     case types.PRODUCT_ADDING:
       currentProducts2 = isEmpty(state.products) ? [] : state.products;
       let addProduct = isEmpty(action.payload) ? [] : [action.payload];

--- a/src/reducers/productReducer.js
+++ b/src/reducers/productReducer.js
@@ -6,9 +6,6 @@ const initialState = {
   // Stores ALL products. Shouldn't clear this.
   products: [],
 
-  // Stores ALL products images.
-  images: [],
-
   // Stores ALL product categories.
   product_category: [],
 
@@ -204,38 +201,6 @@ export default function(state = initialState, action) {
             ? action.payload.slice(0, 12)
             : action.payload
       };
-    case types.GET_PRODUCT_IMAGE:
-      let newImage = action.payload;
-      let productId = action.productId;
-
-      let currentImages = isEmpty(state.images) ? [] : state.images;
-      let oldImages = isEmpty(currentImages[productId]) ? [] : currentImages[productId];
-
-      // prevent duplicate images.
-      let newImages = isEmpty(newImage)
-        ? oldImages :
-        [
-          ...new Map(
-            oldImages
-              .concat(newImage)
-              .map(o => [o['imgName'], o])
-          ).values()
-        ];
-
-      currentImages[productId] = newImages;
-
-      return {
-        ...state,
-        images: currentImages
-      }
-    case types.CLEAR_PRODUCT_IMAGES:
-      productId = action.payload;
-      newImages = isEmpty(state.images) ? [] : state.images;
-      newImages[productId] = [];
-      return {
-        ...state,
-        images: newImages
-      }
     case types.PRODUCT_ADDING:
       currentProducts2 = isEmpty(state.products) ? [] : state.products;
       let addProduct = isEmpty(action.payload) ? [] : [action.payload];


### PR DESCRIPTION
If the product list was empty for even a split second (ie. after search while the results are being fetched), render would return nothing, which is not allowed. Just added an else to return an empty table while loading. Optionally we could put a spinner here but I didn't want my eyes to hurt today.