### PR TITLE
Saved changes | Reset button for image editor

### DIFF
--- a/src/components/portal/detailedProduct/DetailedProduct.js
+++ b/src/components/portal/detailedProduct/DetailedProduct.js
@@ -16,8 +16,6 @@ class DetailedProduct extends Component {
     this.state = {
       activeTab: 0
     };
-
-    this.props.getProduct(this.props.match.params.productId);
   }
 
   componentDidMount() {

--- a/src/components/portal/detailedProduct/ProductDescription.js
+++ b/src/components/portal/detailedProduct/ProductDescription.js
@@ -59,11 +59,16 @@ class ProductDescription extends Component {
     this.onCancel = this.onCancel.bind(this);
     this.onDrop = this.onDrop.bind(this);
     this.showVendor = this.showVendor.bind(this);
+    this.resetImgEditor = this.resetImgEditor.bind(this);
   }
 
   // Fixes no-op error.
   componentWillUnmount() {
     this.props.product.single = null;
+  }
+
+  resetImgEditor() {
+    this.setState({ changed: false, isEditingImg: true });
   }
 
   onDrop(pictureDataURLs, pictureFiles) {
@@ -247,6 +252,8 @@ class ProductDescription extends Component {
         maxFileSize={262144}
         startingImages={imageData}
         startingFiles={imageNames}
+        disabled={this.state.changed}
+        resetCallback={this.resetImgEditor}
       />
     );
   }
@@ -479,13 +486,13 @@ class ProductDescription extends Component {
                 </div>
               </div>
             </div>
-            {!this.state.isEditingImg ? (
+            {!this.state.isEditingImg && !this.state.changed ? (
               <ProductCarousel prod={this.props.product.single} />
             ) : (
               this.showImgEditor()
             )}
             {this.props.user.role === 'admin' &&
-              !this.state.isEditingImg && (
+              !this.state.isEditingImg && !this.state.changed && (
                 <Button
                   className="btn more-rounded hover-t-b btn-sm mx-auto surround-parent parent-wide mt-2"
                   onClick={this.buttonCallbackImg}
@@ -494,12 +501,13 @@ class ProductDescription extends Component {
                 </Button>
               )}
             {this.props.user.role === 'admin' &&
-              this.state.isEditingImg && (
+              (this.state.isEditingImg || this.state.changed) && (
                 <Button
+                  disabled={this.state.changed}
                   className="btn more-rounded hover-t-b btn-sm mx-auto surround-parent parent-wide mt-2"
                   onClick={this.handleCallbackImg}
                 >
-                  Save changes
+                  {!this.state.changed ? 'Save changes' : 'Saved changes'}
                 </Button>
               )}
           </div>

--- a/src/components/portal/products/ImageUploader.js
+++ b/src/components/portal/products/ImageUploader.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import FlipMove from 'react-flip-move';
 import UploadIcon from '../../../img/UploadIcon.svg';
 import md5 from 'js-md5';
+import Button from 'react-ions/lib/components/Button';
 
 class ImageUploader extends Component {
   constructor(props) {
@@ -13,9 +14,20 @@ class ImageUploader extends Component {
       notAcceptedFileType: [],
       notAcceptedFileSize: []
     };
+    this.startingImages = this.props.startingImages;
+    this.startingFiles = this.props.startingFiles;
     this.inputElement = '';
     this.onDropFile = this.onDropFile.bind(this);
     this.triggerFileUpload = this.triggerFileUpload.bind(this);
+    this.restoreStarting = this.restoreStarting.bind(this);
+
+    this.resetCallback = this.props.resetCallback;
+  }
+
+  // Restore the "starting files"
+  restoreStarting() {
+    this.setState({ pictures: this.startingImages, files: this.startingFiles });
+    this.resetCallback();
   }
 
   /*
@@ -118,7 +130,7 @@ class ImageUploader extends Component {
    Render the upload icon
    */
   renderIcon() {
-    if (this.props.withIcon) {
+    if (this.props.withIcon && !this.props.disabled) {
       return <img src={UploadIcon} className="uploadIcon" alt="Upload Icon" />;
     }
   }
@@ -127,11 +139,25 @@ class ImageUploader extends Component {
 	 Render label
 	 */
   renderLabel() {
-    if (this.props.withLabel) {
+    if (this.props.withLabel && !this.props.disabled) {
       return (
         <p className={this.props.labelClass} style={this.props.labelStyles}>
           {this.props.label}
         </p>
+      );
+    } else {
+      return (
+        <div>
+          <p className={this.props.labelClass} style={this.props.labelStyles}>
+            Your changes have been saved. You must click the Finish button to finalise.
+          </p>
+          <Button
+            onClick={this.restoreStarting}
+            className="btn more-rounded hover-t-b btn-sm mx-auto surround-parent parent-wide mt-2"
+          >
+            Reset changes
+          </Button>
+        </div>
       );
     }
   }
@@ -217,12 +243,14 @@ class ImageUploader extends Component {
     return this.state.pictures.map((picture, index) => {
       return (
         <div key={index} className="uploadPictureContainer">
-          <div
-            className="deleteImage"
-            onClick={() => this.removeImage(picture)}
-          >
-            X
-          </div>
+          {!this.props.disabled && (
+            <div
+              className="deleteImage"
+              onClick={() => this.removeImage(picture)}
+            >
+              X
+            </div>
+          )}
           <img src={picture} className="uploadPicture" alt="preview" />
         </div>
       );
@@ -239,22 +267,26 @@ class ImageUploader extends Component {
           {this.renderIcon()}
           {this.renderLabel()}
           <div className="errorsContainer">{this.renderErrors()}</div>
-          <button
-            type={this.props.buttonType}
-            className={'chooseFileButton ' + this.props.buttonClassName}
-            style={this.props.buttonStyles}
-            onClick={this.triggerFileUpload}
-          >
-            {this.props.buttonText}
-          </button>
-          <input
-            type="file"
-            ref={input => (this.inputElement = input)}
-            name={this.props.name}
-            multiple={!this.props.singleImage}
-            onChange={this.onDropFile}
-            accept={this.props.accept}
-          />
+          {!this.props.disabled && (
+            <div>
+              <button
+                type={this.props.buttonType}
+                className={'chooseFileButton ' + this.props.buttonClassName}
+                style={this.props.buttonStyles}
+                onClick={this.triggerFileUpload}
+              >
+                {this.props.buttonText}
+              </button>
+              <input
+                type="file"
+                ref={input => (this.inputElement = input)}
+                name={this.props.name}
+                multiple={!this.props.singleImage}
+                onChange={this.onDropFile}
+                accept={this.props.accept}
+              />
+            </div>
+          )}
           {this.props.withPreview ? this.renderPreview() : null}
         </div>
       </div>


### PR DESCRIPTION
Disabled viewing the carousel after editing images because we can't show "edited" images until they reload the page.

Now it will tell you that your changes were successful and you need to click "Finish" to finalise your edits, and I've appended a reset button so you can start again without restarting the page.