### PR TITLE
Feature/griz 399

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -8,6 +8,7 @@ import {
   stopJWTRefreshChecker
 } from '../utils/RefreshToken';
 import isEmpty from '../validation/is-empty';
+import { emptyCart } from './cartActions';
 
 // Get Admins List
 export const getUsers = (role, id) => dispatch => {
@@ -136,6 +137,7 @@ export const logoutUser = () => dispatch => {
         auth2.disconnect();
       }
     }
+    emptyCart();
   }
 
   axios.put(AUTH_API_GATEWAY + '/logout');

--- a/src/components/layout/Navbar.js
+++ b/src/components/layout/Navbar.js
@@ -119,10 +119,15 @@ class Navbar extends Component {
           !this.props.user.isRegistered
         ) {
           toast.success(
-            <span onClick={this.doRedirect}>
-              Hello {this.props.user.googleProfile.given_name}! Click HERE to
-              update your profile.
-            </span>
+            <div>
+              <span onClick={this.doRedirect}>
+                Hello {this.props.user.googleProfile.given_name}!
+              </span>
+              <br />
+              <span onClick={this.doRedirect}>
+                Click HERE to update your profile.
+              </span>
+            </div>
           );
         } else {
           this.notify(this.props.user.googleProfile.given_name);

--- a/src/components/portal/customer/ProfileForm.js
+++ b/src/components/portal/customer/ProfileForm.js
@@ -79,7 +79,11 @@ class ProfileForm extends Component {
       };
       this.props.createOrUpdateProfile(profileData);
       toast.success('Profile updated!');
-      this.props.onCancel();
+      if (this.props.previousPath === '/shoppingcart') {
+        this.props.history.push('/shoppingcart');
+      } else {
+        this.props.onCancel();
+      }
     } else {
       toast.info('Please check your input!');
       this.setState({ isValid: false });

--- a/src/components/portal/customer/ShoppingCart.js
+++ b/src/components/portal/customer/ShoppingCart.js
@@ -28,6 +28,8 @@ class ShoppingCart extends Component {
 
     this.onChange = this.onChange.bind(this);
     this.onClick = this.onClick.bind(this);
+    this.goToPayment = this.goToPayment.bind(this);
+    this.doRedirect = this.doRedirect.bind(this);
 
     this.triggeredFetch = false;
     this.totalPrice = 0;
@@ -86,6 +88,34 @@ class ShoppingCart extends Component {
   // Adding the total price for all the items in cart
   addToMoney(additionalPrice) {
     this.totalPrice += additionalPrice;
+  }
+
+  doRedirect() {
+    this.props.history.push({
+      pathname: '/settings',
+      state: { tabId: 'ProfileForm', previousPath: '/shoppingcart' }
+    });
+  }
+
+  toast_Id = null;
+  goToPayment() {
+    if (this.props.user.isAuthenticated) {
+      if (!this.props.user.isRegistered) {
+        if (!toast.isActive(this.toast_Id)) {
+          toast.info(
+            <span onClick={this.doRedirect}>
+              Click HERE to update your address!
+            </span>
+          );
+        }
+      } else {
+        this.props.history.push('/payment');
+      }
+    } else {
+      if (!toast.isActive(this.toast_Id)) {
+        toast.info('Please sign in first!');
+      }
+    }
   }
 
   show() {
@@ -173,12 +203,12 @@ class ShoppingCart extends Component {
               ${this.totalPrice}
             </div>
             {!isEmpty(this.props.product.cart) && (
-              <Link
+              <button
                 className="mt-3 btn orange-b surround-parent w-75 more-rounded"
-                to="/payment"
+                onClick={this.goToPayment}
               >
                 Checkout
-              </Link>
+              </button>
             )}
             <Link
               className="mt-3 btn btn-outline-success surround-parent w-75 more-rounded"
@@ -205,7 +235,8 @@ ShoppingCart.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  product: state.product
+  product: state.product,
+  user: state.user
 });
 
 export default connect(

--- a/src/components/portal/customer/UserSettings.js
+++ b/src/components/portal/customer/UserSettings.js
@@ -11,7 +11,8 @@ class UserSettings extends Component {
     super(props);
     this.toggle = this.toggle.bind(this);
     this.state = {
-      activeTab: this.props.location.state.tabId
+      activeTab: this.props.location.state.tabId,
+      previousPath: this.props.location.state.previousPath
     };
     this.onProfileFormCancel = this.onProfileFormCancel.bind(this);
     this.onShowProfileForm = this.onShowProfileForm.bind(this);
@@ -83,7 +84,10 @@ class UserSettings extends Component {
               <OrderHistory />
             </TabPane>
             <TabPane tabId="ProfileForm">
-              <ProfileForm onCancel={this.onProfileFormCancel} />
+              <ProfileForm
+                onCancel={this.onProfileFormCancel}
+                previousPath={this.state.previousPath}
+              />
             </TabPane>
           </TabContent>
         </Col>

--- a/src/components/portal/payment/Payment.js
+++ b/src/components/portal/payment/Payment.js
@@ -137,6 +137,7 @@ class Payment extends Component {
                 <PaypalExpressBtn
                   client={client}
                   currency={'AUD'}
+                  shipping={1}
                   total={this.calcOrderPrice()}
                   onSuccess={this.onSuccess}
                   onCancel={this.onCancel}


### PR DESCRIPTION
- Clear cart on log out so logging in with different account wont see it.
- Disable adding shipping address on paypal check out as we dont have BE func to handle this (so far).
- Shipping address is default to user's address (not persisted in user order table in db though. Reason: No BE func)
- Guest must sign in to pay.
- Signed in user with no address needs to update their address first
- Redirect back to shopping cart after updating info (if redirected from cart)
 - Etc.