### PR TITLE
Defect/gri z 441 (Fixed issue causing high-ID products to have no img on shopping cart)

### DIFF
--- a/src/actions/productsActions.js
+++ b/src/actions/productsActions.js
@@ -90,7 +90,7 @@ export const getProductsVendor = (userid, index) => dispatch => {
 };
 
 // Get Product with Imgs
-export const getProduct = productId => dispatch => {
+export const getProduct = (productId, addToList) => dispatch => {
   dispatch(clearErrors());
   dispatch(setProductLoading());
   axios
@@ -98,7 +98,8 @@ export const getProduct = productId => dispatch => {
     .then(res => {
       dispatch({
         type: types.GET_PRODUCT,
-        payload: res.data
+        payload: res.data,
+        addToList: addToList
       });
       if (!isEmpty(res.data)) {
         if (!isEmpty(res.data.productId)) {

--- a/src/components/portal/customer/OrderHistory.js
+++ b/src/components/portal/customer/OrderHistory.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getUserOrder } from '../../../actions/userActions';
-import { getProducts } from '../../../actions/productsActions';
+import { getProducts, getProduct } from '../../../actions/productsActions';
 import TrackOrderModal from './TrackOrderModal';
 import Spinner from '../../common/Spinner';
 import isEmpty from '../../../validation/is-empty';
@@ -13,9 +13,9 @@ import ProductImage from '../common/ProductImage';
 class OrderHistory extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      userId: 1
-    };
+
+    this.fetchedProdIds = {};
+
     this.props.getUserOrder();
     if (
       isEmpty(this.props.product.products) ||
@@ -27,23 +27,30 @@ class OrderHistory extends Component {
 
   getProductDetails(prodId) {
     if (!isEmpty(this.props.product.products)) {
-      return this.props.product.products
-        .filter(item => item.productId === parseInt(prodId, 10))
-        .map(prod => (
-          <div className="row m-3" key={prodId}>
-            <div className="col-5 my-auto mx-auto">
-              <ProductImage prod={prod} />
+      if (isEmpty(this.props.product.products.filter(
+        product => product.productId === parseInt(prodId, 10)
+      )) && isEmpty(this.fetchedProdIds[prodId])) {
+          this.props.getProduct(parseInt(prodId, 10), true);
+          this.fetchedProdIds[prodId] = true;
+      } else {
+        return this.props.product.products
+          .filter(item => item.productId === parseInt(prodId, 10))
+          .map(prod => (
+            <div className="row m-3" key={prodId}>
+              <div className="col-5 my-auto mx-auto">
+                <ProductImage prod={prod} />
+              </div>
+              <div className="col-7">
+                <CardBody>
+                  <CardTitle className="text-left">{prod.name}</CardTitle>
+                  <CardText className="text-left fnt-weight-400 dscrptnSize-8">
+                    {prod.desc}
+                  </CardText>
+                </CardBody>
+              </div>
             </div>
-            <div className="col-7">
-              <CardBody>
-                <CardTitle className="text-left">{prod.name}</CardTitle>
-                <CardText className="text-left fnt-weight-400 dscrptnSize-8">
-                  {prod.desc}
-                </CardText>
-              </CardBody>
-            </div>
-          </div>
-        ));
+          ));
+      }
     }
   }
 
@@ -114,7 +121,8 @@ class OrderHistory extends Component {
 
 OrderHistory.propTypes = {
   getUserOrder: PropTypes.func.isRequired,
-  getProducts: PropTypes.func.isRequired
+  getProducts: PropTypes.func.isRequired,
+  getProduct: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -127,6 +135,7 @@ export default connect(
   mapStateToProps,
   {
     getUserOrder,
-    getProducts
+    getProducts,
+    getProduct
   }
 )(OrderHistory);

--- a/src/reducers/productReducer.js
+++ b/src/reducers/productReducer.js
@@ -257,6 +257,14 @@ export default function(state = initialState, action) {
         vendorIndex: VendorIndex
       };
     case types.GET_PRODUCT:
+      if (action.addToList) {
+        newProducts = state.products;
+        newProducts.push(action.payload);
+        return {
+          ...state,
+          products: newProducts
+        };
+      }
       return {
         ...state,
         single: action.payload


### PR DESCRIPTION
- If it wasn't present in products (because it was off the loaded page), we are now manually fetching the products
- Note that this now has a warning thrown in console, but this is NOT relevant (for some reason it thinks we are changing the state in the new code, but we are simply editing 'this', which react docs specifies should not throw this error (See https://medium.freecodecamp.org/where-do-i-belong-a-guide-to-saving-react-component-data-in-state-store-static-and-this-c49b335e2a00)